### PR TITLE
Makefile: put LDFLAGS last so that gcc links to shared libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ DESTDIR=
 all: pam_network_namespace.so
 
 pam_network_namespace.so: pam_network_namespace.o
-	$(CC) -shared $(LDFLAGS) -o $@ $^
+	$(CC) -shared -o $@ $^ $(LDFLAGS)
 
 test.bin: pam_network_namespace.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -DTEST -o $@ $^
+	$(CC) $(CFLAGS) -DTEST -o $@ $^ $(LDFLAGS)
 
 test: test.bin
 	./test.bin echo "Test success!"


### PR DESCRIPTION
With the `LDFLAGS` in the order they currently are, gcc `gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609` produces a `pam_network_namespace.so` that isn't linked to much.

Before:

```
# ldd pam_network_namespace.so 
	linux-vdso.so.1 =>  (0x00007fff82f3b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2d59f6e000)
	/lib64/ld-linux-x86-64.so.2 (0x000055fb32e45000)
```

After:

```
# ldd pam_network_namespace.so
	linux-vdso.so.1 =>  (0x00007ffd56971000)
	libnl-route-3.so.200 => /usr/lib/x86_64-linux-gnu/libnl-route-3.so.200 (0x00007f34a2766000)
	libnl-3.so.200 => /lib/x86_64-linux-gnu/libnl-3.so.200 (0x00007f34a2547000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f34a217d000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f34a1f60000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f34a1c57000)
	/lib64/ld-linux-x86-64.so.2 (0x000055c7f2d9d000)
```